### PR TITLE
prompt: support custom io (Reader/Writer)

### DIFF
--- a/mocks/prompt/mock_prompter.go
+++ b/mocks/prompt/mock_prompter.go
@@ -10,6 +10,7 @@ package mock_prompt
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 	time "time"
 
@@ -276,6 +277,18 @@ func (mr *MockPrompterMockRecorder) SetHistoryListPrefix(arg0 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHistoryListPrefix", reflect.TypeOf((*MockPrompter)(nil).SetHistoryListPrefix), arg0)
 }
 
+// SetInput mocks base method.
+func (m *MockPrompter) SetInput(arg0 io.Reader) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetInput", arg0)
+}
+
+// SetInput indicates an expected call of SetInput.
+func (mr *MockPrompterMockRecorder) SetInput(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInput", reflect.TypeOf((*MockPrompter)(nil).SetInput), arg0)
+}
+
 // SetKeyMap mocks base method.
 func (m *MockPrompter) SetKeyMap(arg0 prompt.KeyMap) error {
 	m.ctrl.T.Helper()
@@ -288,6 +301,18 @@ func (m *MockPrompter) SetKeyMap(arg0 prompt.KeyMap) error {
 func (mr *MockPrompterMockRecorder) SetKeyMap(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKeyMap", reflect.TypeOf((*MockPrompter)(nil).SetKeyMap), arg0)
+}
+
+// SetOutput mocks base method.
+func (m *MockPrompter) SetOutput(arg0 io.Writer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOutput", arg0)
+}
+
+// SetOutput indicates an expected call of SetOutput.
+func (mr *MockPrompterMockRecorder) SetOutput(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOutput", reflect.TypeOf((*MockPrompter)(nil).SetOutput), arg0)
 }
 
 // SetPrefix mocks base method.

--- a/powerline/powerline_test.go
+++ b/powerline/powerline_test.go
@@ -51,7 +51,7 @@ func BenchmarkPowerlineRender(b *testing.B) {
 	}
 }
 
-func TestPowerlineRender(t *testing.T) {
+func TestPowerline_Render(t *testing.T) {
 	segUser := &Segment{}
 	segUser.SetContent("username")
 	segUser.SetIcon("👤")

--- a/powerline/segment_test.go
+++ b/powerline/segment_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSegmentColor(t *testing.T) {
+func TestSegment_Color(t *testing.T) {
 	s := Segment{}
 
 	c := s.Color()
@@ -30,7 +30,7 @@ func TestSegmentColor(t *testing.T) {
 	assert.Equal(t, *s.color, c)
 }
 
-func TestSegmentHasChanges(t *testing.T) {
+func TestSegment_HasChanges(t *testing.T) {
 	s := Segment{}
 	assert.False(t, s.HasChanges())
 
@@ -38,7 +38,7 @@ func TestSegmentHasChanges(t *testing.T) {
 	assert.True(t, s.HasChanges())
 }
 
-func TestSegmentRender(t *testing.T) {
+func TestSegment_Render(t *testing.T) {
 	s := Segment{}
 	assert.Equal(t, "", s.Render())
 
@@ -66,7 +66,7 @@ func TestSegmentRender(t *testing.T) {
 	assert.Equal(t, s.color.Sprint("[🌐 0.0.0.0]"), s.Render())
 }
 
-func TestSegmentResetColor(t *testing.T) {
+func TestSegment_ResetColor(t *testing.T) {
 	s := Segment{}
 	s.SetColor(prompt.Color{
 		Foreground: termenv.ANSI256Color(0),
@@ -78,7 +78,7 @@ func TestSegmentResetColor(t *testing.T) {
 	assert.Nil(t, s.color)
 }
 
-func TestSegmentSetColor(t *testing.T) {
+func TestSegment_SetColor(t *testing.T) {
 	s := Segment{}
 	s.SetContent("foo")
 	s.hasChanges = false
@@ -108,7 +108,7 @@ func TestSegmentSetColor(t *testing.T) {
 	assert.True(t, s.hasChanges)
 }
 
-func TestSegmentSetContent(t *testing.T) {
+func TestSegment_SetContent(t *testing.T) {
 	s := Segment{}
 
 	s.SetContent("foo", "tag1")
@@ -123,7 +123,7 @@ func TestSegmentSetContent(t *testing.T) {
 	assert.False(t, s.HasChanges())
 }
 
-func TestSegmentSetIcon(t *testing.T) {
+func TestSegment_SetIcon(t *testing.T) {
 	s := Segment{}
 	s.SetContent("foo")
 	s.hasChanges = false
@@ -139,7 +139,7 @@ func TestSegmentSetIcon(t *testing.T) {
 	assert.False(t, s.hasChanges)
 }
 
-func TestSegmentWidth(t *testing.T) {
+func TestSegment_Width(t *testing.T) {
 	s := Segment{}
 	assert.Equal(t, 0, s.Width())
 

--- a/prompt/auto_completer_test.go
+++ b/prompt/auto_completer_test.go
@@ -19,14 +19,6 @@ func BenchmarkAutoComplete(b *testing.B) {
 	}
 }
 
-func TestSuggestionString(t *testing.T) {
-	s := Suggestion{
-		Value: "val",
-		Hint:  "hint",
-	}
-	assert.Equal(t, "val: hint", s.String())
-}
-
 func TestAutoCompleteGoLangKeywords(t *testing.T) {
 	ac := AutoCompleteGoLangKeywords()
 
@@ -161,4 +153,12 @@ func TestAutoCompleteWords(t *testing.T) {
 		assert.Equal(t, "bar", matches[1].Value)
 		assert.Equal(t, "foo", matches[2].Value)
 	})
+}
+
+func TestSuggestion_String(t *testing.T) {
+	s := Suggestion{
+		Value: "val",
+		Hint:  "hint",
+	}
+	assert.Equal(t, "val: hint", s.String())
 }

--- a/prompt/buffer_test.go
+++ b/prompt/buffer_test.go
@@ -13,7 +13,7 @@ func getNewBuffer(t *testing.T) *buffer {
 	return b
 }
 
-func TestBufferCursor(t *testing.T) {
+func TestBuffer_Cursor(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.Cursor())
 
@@ -21,7 +21,7 @@ func TestBufferCursor(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 1, Column: 3}, b.Cursor())
 }
 
-func TestBufferDeleteBackward(t *testing.T) {
+func TestBuffer_DeleteBackward(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.lines = []string{"abc", "def"}
@@ -69,7 +69,7 @@ func TestBufferDeleteBackward(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferDeleteBackwardToBeginningOfLine(t *testing.T) {
+func TestBuffer_DeleteBackwardToBeginningOfLine(t *testing.T) {
 	b := getNewBuffer(t)
 	b.InsertString("foo bar baz")
 	b.MoveWordLeft()
@@ -78,7 +78,7 @@ func TestBufferDeleteBackwardToBeginningOfLine(t *testing.T) {
 	assert.Equal(t, "baz", b.String())
 }
 
-func TestBufferDeleteForward(t *testing.T) {
+func TestBuffer_DeleteForward(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.lines = []string{"abc", "def"}
@@ -132,7 +132,7 @@ func TestBufferDeleteForward(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 2}, b.cursor)
 }
 
-func TestBufferDeleteForwardToEndOfLine(t *testing.T) {
+func TestBuffer_DeleteForwardToEndOfLine(t *testing.T) {
 	b := getNewBuffer(t)
 	b.InsertString("foo baz bar")
 	b.MoveWordLeft()
@@ -142,7 +142,7 @@ func TestBufferDeleteForwardToEndOfLine(t *testing.T) {
 	assert.Equal(t, "foo ", b.String())
 }
 
-func TestBufferDeleteWordBackward(t *testing.T) {
+func TestBuffer_DeleteWordBackward(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.lines = []string{"abc def"}
@@ -206,7 +206,7 @@ func TestBufferDeleteWordBackward(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferDeleteWordForward(t *testing.T) {
+func TestBuffer_DeleteWordForward(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.lines = []string{"abc def"}
@@ -261,7 +261,7 @@ func TestBufferDeleteWordForward(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferDisplay(t *testing.T) {
+func TestBuffer_Display(t *testing.T) {
 	b := getNewBuffer(t)
 
 	lines, cur := b.Display()
@@ -274,7 +274,7 @@ func TestBufferDisplay(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 1, Column: 3}, cur)
 }
 
-func TestBufferHasChanges(t *testing.T) {
+func TestBuffer_HasChanges(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.linesChanged.Clear()
@@ -293,7 +293,7 @@ func TestBufferHasChanges(t *testing.T) {
 	assert.False(t, b.HasChanges())
 }
 
-func TestBufferInsert(t *testing.T) {
+func TestBuffer_Insert(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.Insert('\n')
@@ -367,7 +367,7 @@ func TestBufferInsert(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 5}, b.cursor)
 }
 
-func TestBufferIsDone(t *testing.T) {
+func TestBuffer_IsDone(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.False(t, b.IsDone())
 
@@ -375,7 +375,7 @@ func TestBufferIsDone(t *testing.T) {
 	assert.True(t, b.IsDone())
 }
 
-func TestBufferLength(t *testing.T) {
+func TestBuffer_Length(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.Equal(t, 0, b.Length())
 
@@ -389,7 +389,7 @@ func TestBufferLength(t *testing.T) {
 	assert.Equal(t, 7, b.Length())
 }
 
-func TestBufferLines(t *testing.T) {
+func TestBuffer_Lines(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.Equal(t, []string{""}, b.Lines())
 
@@ -400,7 +400,7 @@ func TestBufferLines(t *testing.T) {
 	assert.Equal(t, []string{"foo", "bar", ""}, b.Lines())
 }
 
-func TestBufferMakeWordCapitalCase(t *testing.T) {
+func TestBuffer_MakeWordCapitalCase(t *testing.T) {
 	b := getNewBuffer(t)
 	b.MakeWordCapitalCase()
 
@@ -420,7 +420,7 @@ func TestBufferMakeWordCapitalCase(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 2, Column: 3}, b.cursor)
 }
 
-func TestBufferMakeWordLowerCase(t *testing.T) {
+func TestBuffer_MakeWordLowerCase(t *testing.T) {
 	b := getNewBuffer(t)
 	b.MakeWordLowerCase()
 	b.lines = []string{"ABC", "DEF", "GHI"}
@@ -439,7 +439,7 @@ func TestBufferMakeWordLowerCase(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 2, Column: 3}, b.cursor)
 }
 
-func TestBufferMakeWordUpperCase(t *testing.T) {
+func TestBuffer_MakeWordUpperCase(t *testing.T) {
 	b := getNewBuffer(t)
 	b.MakeWordUpperCase()
 	b.lines = []string{"abc", "def", "ghi"}
@@ -458,7 +458,7 @@ func TestBufferMakeWordUpperCase(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 2, Column: 3}, b.cursor)
 }
 
-func TestBufferMarkAsDone(t *testing.T) {
+func TestBuffer_MarkAsDone(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.False(t, b.done)
 
@@ -466,7 +466,7 @@ func TestBufferMarkAsDone(t *testing.T) {
 	assert.True(t, b.done)
 }
 
-func TestBufferMoveDown(t *testing.T) {
+func TestBuffer_MoveDown(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -491,7 +491,7 @@ func TestBufferMoveDown(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 1, Column: 3}, b.cursor)
 }
 
-func TestBufferMoveLeft(t *testing.T) {
+func TestBuffer_MoveLeft(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -539,7 +539,7 @@ func TestBufferMoveLeft(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferMoveRight(t *testing.T) {
+func TestBuffer_MoveRight(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.MoveRight(1)
@@ -591,7 +591,7 @@ func TestBufferMoveRight(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 1, Column: 3}, b.cursor)
 }
 
-func TestBufferMoveToBeginning(t *testing.T) {
+func TestBuffer_MoveToBeginning(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.InsertString("foo")
@@ -599,7 +599,7 @@ func TestBufferMoveToBeginning(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.Cursor())
 }
 
-func TestBufferMoveToBeginningOfLine(t *testing.T) {
+func TestBuffer_MoveToBeginningOfLine(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -620,7 +620,7 @@ func TestBufferMoveToBeginningOfLine(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferMoveToEnd(t *testing.T) {
+func TestBuffer_MoveToEnd(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.InsertString("foo")
@@ -628,7 +628,7 @@ func TestBufferMoveToEnd(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 3}, b.Cursor())
 }
 
-func TestBufferMoveToEndOfLine(t *testing.T) {
+func TestBuffer_MoveToEndOfLine(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -653,7 +653,7 @@ func TestBufferMoveToEndOfLine(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 3}, b.cursor)
 }
 
-func TestBufferMoveUp(t *testing.T) {
+func TestBuffer_MoveUp(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -678,7 +678,7 @@ func TestBufferMoveUp(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 3}, b.cursor)
 }
 
-func TestBufferMoveWordLeft(t *testing.T) {
+func TestBuffer_MoveWordLeft(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -715,7 +715,7 @@ func TestBufferMoveWordLeft(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferMoveWordRight(t *testing.T) {
+func TestBuffer_MoveWordRight(t *testing.T) {
 	b := getNewBuffer(t)
 
 	b.cursor = CursorLocation{Line: 0, Column: 0}
@@ -748,7 +748,7 @@ func TestBufferMoveWordRight(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 1, Column: 0}, b.cursor)
 }
 
-func TestBufferNumLines(t *testing.T) {
+func TestBuffer_NumLines(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.Equal(t, 1, b.NumLines())
 
@@ -756,7 +756,7 @@ func TestBufferNumLines(t *testing.T) {
 	assert.Equal(t, 2, b.NumLines())
 }
 
-func TestBufferReset(t *testing.T) {
+func TestBuffer_Reset(t *testing.T) {
 	b := getNewBuffer(t)
 	b.InsertString("foo")
 
@@ -766,7 +766,7 @@ func TestBufferReset(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 0, Column: 0}, b.cursor)
 }
 
-func TestBufferSet(t *testing.T) {
+func TestBuffer_Set(t *testing.T) {
 	b := getNewBuffer(t)
 	b.tab = "    "
 
@@ -775,7 +775,7 @@ func TestBufferSet(t *testing.T) {
 	assert.Equal(t, CursorLocation{Line: 1, Column: 27}, b.cursor)
 }
 
-func TestBufferString(t *testing.T) {
+func TestBuffer_String(t *testing.T) {
 	b := getNewBuffer(t)
 	assert.Equal(t, "", b.String())
 
@@ -789,7 +789,7 @@ func TestBufferString(t *testing.T) {
 	assert.Equal(t, "abc\ndef", b.String())
 }
 
-func TestBufferGetWordAtCursor(t *testing.T) {
+func TestBuffer_getWordAtCursor(t *testing.T) {
 	b := getNewBuffer(t)
 	b.InsertString("foo bar baz foo")
 

--- a/prompt/color_test.go
+++ b/prompt/color_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestColorInvert(t *testing.T) {
+func TestColor_Invert(t *testing.T) {
 	c := Color{
 		Foreground: termenv.ANSI256Color(194),
 		Background: termenv.ANSI256Color(56),
@@ -20,7 +20,7 @@ func TestColorInvert(t *testing.T) {
 	assert.Equal(t, termenv.ANSI256Color(194), c2.Background)
 }
 
-func TestColorSprint(t *testing.T) {
+func TestColor_Sprint(t *testing.T) {
 	c := Color{}
 	assert.Equal(t, "foo", c.Sprint("foo"))
 
@@ -31,7 +31,7 @@ func TestColorSprint(t *testing.T) {
 	assert.Equal(t, "\x1b[38;5;194;48;5;56mfoo\x1b[0m", c.Sprint("foo"))
 }
 
-func TestColorSprintf(t *testing.T) {
+func TestColor_Sprintf(t *testing.T) {
 	c := Color{
 		Foreground: termenv.ANSI256Color(194),
 		Background: termenv.ANSI256Color(56),

--- a/prompt/cursor_test.go
+++ b/prompt/cursor_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCursorLocationString(t *testing.T) {
+func TestCursorLocation_String(t *testing.T) {
 	cl := CursorLocation{Line: 12, Column: 13}
 
 	assert.Equal(t, "[13, 14]", cl.String())

--- a/prompt/errors.go
+++ b/prompt/errors.go
@@ -14,10 +14,6 @@ var ErrDuplicateKeyAssignment = errors.New("duplicate key assignment")
 // does not make sense.
 var ErrInvalidDimensions = errors.New("invalid dimensions")
 
-// ErrNonInteractiveShell is returned when the Prompter is being invoked on a
-// shell which is not-interactive (ex.: script run in headless mode).
-var ErrNonInteractiveShell = errors.New("non-interactive shell")
-
 // ErrUnsupportedChromaLanguage is returned when Syntax-Highlighting is
 // requested with Chroma library with a language that it does not understand.
 var ErrUnsupportedChromaLanguage = errors.New("unsupported language for chroma")

--- a/prompt/history_test.go
+++ b/prompt/history_test.go
@@ -24,7 +24,7 @@ var (
 	}
 )
 
-func TestHistoryAppend(t *testing.T) {
+func TestHistory_Append(t *testing.T) {
 	h := History{}
 	assert.Len(t, h.Commands, 0)
 
@@ -35,7 +35,7 @@ func TestHistoryAppend(t *testing.T) {
 	assert.Len(t, h.Commands, 2)
 }
 
-func TestHistoryGet(t *testing.T) {
+func TestHistory_Get(t *testing.T) {
 	h := History{}
 	for _, cmd := range testHistoryCommands {
 		h.Append(cmd.Command)
@@ -46,7 +46,7 @@ func TestHistoryGet(t *testing.T) {
 	assert.Equal(t, "", h.Get(2))
 }
 
-func TestHistoryGetNext(t *testing.T) {
+func TestHistory_GetNext(t *testing.T) {
 	h := History{}
 	for _, cmd := range testHistoryCommands {
 		h.Append(cmd.Command)
@@ -58,7 +58,7 @@ func TestHistoryGetNext(t *testing.T) {
 	assert.Equal(t, "", h.GetNext())
 }
 
-func TestHistoryGetPrev(t *testing.T) {
+func TestHistory_GetPrev(t *testing.T) {
 	h := History{}
 	for _, cmd := range testHistoryCommands {
 		h.Append(cmd.Command)
@@ -69,7 +69,7 @@ func TestHistoryGetPrev(t *testing.T) {
 	assert.Equal(t, testHistoryCommands[0].Command, h.GetPrev())
 }
 
-func TestHistoryRender(t *testing.T) {
+func TestHistory_Render(t *testing.T) {
 	h := History{}
 	for _, cmd := range testHistoryCommands {
 		h.Append(cmd.Command, time.Time(cmd.Timestamp))
@@ -104,7 +104,7 @@ func TestHistoryRender(t *testing.T) {
 	assert.Equal(t, expected, h.Render(3, 0))
 }
 
-func TestPromptProcessHistoryCommand(t *testing.T) {
+func TestPrompt_processHistoryCommand(t *testing.T) {
 	p := generateTestPrompt(t, context.Background())
 	p.SetHistory([]HistoryCommand{
 		{Command: "foo"},

--- a/prompt/key_map_test.go
+++ b/prompt/key_map_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestKeyMapReverse(t *testing.T) {
+func TestKeyMap_reverse(t *testing.T) {
 	k := KeyMapDefault
 	kr, err := k.reverse()
 	assert.NotNil(t, kr)

--- a/prompt/prompt_handle.go
+++ b/prompt/prompt_handle.go
@@ -230,7 +230,7 @@ func (p *prompt) handleKeyAutoComplete(output *termenv.Output, key tea.KeyMsg) e
 }
 
 func (p *prompt) handleKeyInsert(output *termenv.Output, key tea.KeyMsg) error {
-	ks := p.translateKeyToKeySequence(key)
+	ks := translateKeyToKeySequence(key)
 	if shortcut, ok := p.shortcuts[ks]; ok {
 		p.buffer.Set(shortcut)
 		p.buffer.MarkAsDone()

--- a/prompt/prompt_handle_test.go
+++ b/prompt/prompt_handle_test.go
@@ -25,7 +25,7 @@ func generateTestPromptWithBuffer(t *testing.T, ctx context.Context, text string
 	return p
 }
 
-func TestPrompthandleHistoryExec(t *testing.T) {
+func TestPrompt_handleHistoryExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -46,7 +46,7 @@ func TestPrompthandleHistoryExec(t *testing.T) {
 	assert.False(t, p.renderingPaused)
 }
 
-func TestPrompthandleHistoryList(t *testing.T) {
+func TestPrompt_handleHistoryList(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -60,7 +60,7 @@ func TestPrompthandleHistoryList(t *testing.T) {
 	assert.False(t, p.renderingPaused)
 }
 
-func TestPrompthandleKey(t *testing.T) {
+func TestPrompt_handleKey(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -87,7 +87,7 @@ func TestPrompthandleKey(t *testing.T) {
 	})
 }
 
-func TestPrompthandleKeyAutoComplete(t *testing.T) {
+func TestPrompt_handleKeyAutoComplete(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -146,7 +146,7 @@ func TestPrompthandleKeyAutoComplete(t *testing.T) {
 	})
 }
 
-func TestPrompthandleKeyInsert(t *testing.T) {
+func TestPrompt_handleKeyInsert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 

--- a/prompt/prompt_model_test.go
+++ b/prompt/prompt_model_test.go
@@ -3,6 +3,7 @@ package prompt
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -40,8 +41,10 @@ func generateTestPrompt(t *testing.T, ctx context.Context) *prompt {
 	}
 	p.SetHistoryExecPrefix("!")
 	p.SetHistoryListPrefix("!!")
+	p.SetInput(os.Stdin)
+	p.SetOutput(os.Stdout)
 	p.SetPrefixer(PrefixText("[" + t.Name() + "] "))
-	p.SetRefreshInterval(defaultRefreshInterval)
+	p.SetRefreshInterval(DefaultRefreshInterval)
 	p.SetStyle(StyleDefault)
 	p.SetTerminationChecker(TerminationCheckerNone())
 	p.SetWidthEnforcer(WidthEnforcerDefault)
@@ -52,7 +55,7 @@ func generateTestPrompt(t *testing.T, ctx context.Context) *prompt {
 	return p
 }
 
-func TestPromptUpdateModel(t *testing.T) {
+func TestPrompt_updateModel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -70,7 +73,7 @@ func TestPromptUpdateModel(t *testing.T) {
 		p.buffer.InsertString(`select` + ` * from dual`)
 		p.updateModel(true)
 		expectedLines := []string{
-			"[TestPromptUpdateModel/simple_one-liner] \x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;197m*\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mfrom\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;231mdual\x1b[0m\x1b[38;5;232;48;5;6m \x1b[0m",
+			"[TestPrompt_updateModel/simple_one-liner] \x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;197m*\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mfrom\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;231mdual\x1b[0m\x1b[38;5;232;48;5;6m \x1b[0m",
 		}
 		compareModelLines(t, expectedLines, p.linesToRender)
 	})
@@ -85,7 +88,7 @@ func TestPromptUpdateModel(t *testing.T) {
 		p.buffer.InsertString(`select` + ` * from dual`)
 		p.updateModel(true)
 		expectedLines := []string{
-			"[TestPromptUpdateModel/simple_one-liner_with_line-numbers] \x1b[38;5;240;48;5;236m 1 \x1b[0m \x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;197m*\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mfrom\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;231mdual\x1b[0m\x1b[38;5;232;48;5;6m \x1b[0m",
+			"[TestPrompt_updateModel/simple_one-liner_with_line-numbers] \x1b[38;5;240;48;5;236m 1 \x1b[0m \x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;197m*\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mfrom\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;231mdual\x1b[0m\x1b[38;5;232;48;5;6m \x1b[0m",
 		}
 		compareModelLines(t, expectedLines, p.linesToRender)
 	})
@@ -101,12 +104,12 @@ func TestPromptUpdateModel(t *testing.T) {
 		p.updateSuggestionsInternal("", "", -1)
 		p.updateModel(true)
 		expectedLines := []string{
-			"[TestPromptUpdateModel/with_auto-complete] \x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;197m*\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mfrom\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;231mdual\x1b[0m\x1b[38;5;231m",
-			"[TestPromptUpdateModel/with_auto-complete]   \x1b[0m\x1b[38;5;81mwhere\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mrow\x1b[0m\x1b[38;5;232;48;5;6m \x1b[0m",
-			"[TestPromptUpdateModel/with_auto-complete]        \x1b[38;5;16;48;5;214m row       \x1b[0m\x1b[38;5;16;48;5;208m                \x1b[0m",
-			"[TestPromptUpdateModel/with_auto-complete]        \x1b[38;5;16;48;5;45m row_count \x1b[0m\x1b[38;5;0;48;5;39m                \x1b[0m",
-			"[TestPromptUpdateModel/with_auto-complete]        \x1b[38;5;16;48;5;45m rownum    \x1b[0m\x1b[38;5;0;48;5;39m Number of Rows \x1b[0m",
-			"[TestPromptUpdateModel/with_auto-complete]        \x1b[38;5;16;48;5;45m rows      \x1b[0m\x1b[38;5;0;48;5;39m                \x1b[0m",
+			"[TestPrompt_updateModel/with_auto-complete] \x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;197m*\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mfrom\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;231mdual\x1b[0m\x1b[38;5;231m",
+			"[TestPrompt_updateModel/with_auto-complete]   \x1b[0m\x1b[38;5;81mwhere\x1b[0m\x1b[38;5;231m \x1b[0m\x1b[38;5;81mrow\x1b[0m\x1b[38;5;232;48;5;6m \x1b[0m",
+			"[TestPrompt_updateModel/with_auto-complete]        \x1b[38;5;16;48;5;214m row       \x1b[0m\x1b[38;5;16;48;5;208m                \x1b[0m",
+			"[TestPrompt_updateModel/with_auto-complete]        \x1b[38;5;16;48;5;45m row_count \x1b[0m\x1b[38;5;0;48;5;39m                \x1b[0m",
+			"[TestPrompt_updateModel/with_auto-complete]        \x1b[38;5;16;48;5;45m rownum    \x1b[0m\x1b[38;5;0;48;5;39m Number of Rows \x1b[0m",
+			"[TestPrompt_updateModel/with_auto-complete]        \x1b[38;5;16;48;5;45m rows      \x1b[0m\x1b[38;5;0;48;5;39m                \x1b[0m",
 		}
 		compareModelLines(t, expectedLines, p.linesToRender)
 	})

--- a/prompt/prompt_render.go
+++ b/prompt/prompt_render.go
@@ -22,9 +22,11 @@ func (p *prompt) render(ctx context.Context, output *termenv.Output) (rsp string
 	}()
 
 	// instantiate an input reader and begin looking for inputs
+	p.readerMutex.Lock()
 	go p.reader.Begin(ctx)
 	defer func() {
 		p.reader.End()
+		p.readerMutex.Unlock()
 	}()
 
 	// first time render

--- a/prompt/prompt_test.go
+++ b/prompt/prompt_test.go
@@ -192,22 +192,6 @@ func TestPrompt_SendInput(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("send []rune", func(t *testing.T) {
-		mc := gomock.NewController(t)
-		defer mc.Finish()
-		mockReader := mock_input.NewMockReader(mc)
-		gomock.InOrder(
-			mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}),
-			mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}}),
-			mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}),
-		)
-
-		p := generateTestPrompt(t, ctx)
-		p.reader = mockReader
-		err := p.SendInput([]any{[]rune{'a', 'b', 'c'}})
-		assert.Nil(t, err)
-	})
-
 	t.Run("send string error", func(t *testing.T) {
 		mc := gomock.NewController(t)
 		defer mc.Finish()
@@ -222,20 +206,24 @@ func TestPrompt_SendInput(t *testing.T) {
 		assert.Equal(t, errFoo, err)
 	})
 
-	t.Run("send string", func(t *testing.T) {
+	t.Run("send string/[]rune", func(t *testing.T) {
 		mc := gomock.NewController(t)
 		defer mc.Finish()
-		mockReader := mock_input.NewMockReader(mc)
-		gomock.InOrder(
-			mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}),
-			mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}}),
-			mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}),
-		)
 
-		p := generateTestPrompt(t, ctx)
-		p.reader = mockReader
-		err := p.SendInput([]any{"abc"})
-		assert.Nil(t, err)
+		for _, input := range []any{"abc", []rune("abc")} {
+			mockReader := mock_input.NewMockReader(mc)
+			gomock.InOrder(
+				mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}),
+				mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}}),
+				mockReader.EXPECT().Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}),
+			)
+
+			p := generateTestPrompt(t, ctx)
+			p.reader = mockReader
+			err := p.SendInput([]any{input})
+			assert.Nil(t, err)
+
+		}
 	})
 
 	t.Run("send unsupported", func(t *testing.T) {

--- a/prompt/prompter_test.go
+++ b/prompt/prompter_test.go
@@ -1,7 +1,7 @@
 package prompt
 
 import (
-	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +9,35 @@ import (
 
 func TestNew(t *testing.T) {
 	p, err := New()
-	assert.Nil(t, p)
-	assert.NotNil(t, err)
-	assert.True(t, errors.Is(err, ErrNonInteractiveShell))
+	assert.NotNil(t, p)
+	assert.Nil(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+
+	pObj, ok := p.(*prompt)
+	assert.NotNil(t, pObj)
+	assert.True(t, ok)
+	if !ok {
+		t.FailNow()
+	}
+
+	assert.Equal(t, DefaultHistoryExecPrefix, pObj.historyExecPrefix)
+	assert.Equal(t, DefaultHistoryListPrefix, pObj.historyListPrefix)
+	assert.Equal(t, os.Stdin, pObj.input)
+	assert.Equal(t, os.Stdout, pObj.output)
+	assert.Equal(t, PrefixSimple()(), pObj.prefixer())
+	assert.Equal(t, DefaultRefreshInterval, pObj.refreshInterval)
+	assert.NotNil(t, pObj.style)
+	if pObj.style != nil {
+		assert.Equal(t, StyleDefault, *pObj.style)
+	}
+	assert.NotNil(t, pObj.terminationChecker)
+	if pObj.terminationChecker != nil {
+		assert.True(t, pObj.terminationChecker("foo"))
+	}
+	assert.NotNil(t, pObj.widthEnforcer)
+	if pObj.widthEnforcer != nil {
+		assert.Equal(t, WidthEnforcerDefault("foo", 2), pObj.widthEnforcer("foo", 2))
+	}
 }

--- a/prompt/style_test.go
+++ b/prompt/style_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStyleValidate(t *testing.T) {
+func TestStyle_Validate(t *testing.T) {
 	s := StyleDefault
 	err := s.Validate()
 	assert.Nil(t, err)
@@ -30,7 +30,7 @@ func TestStyleValidate(t *testing.T) {
 	assert.Contains(t, err.Error(), "width-min [50] cannot be greater than width-max [40]")
 }
 
-func TestScrollbarGenerate(t *testing.T) {
+func TestStyleScrollbar_Generate(t *testing.T) {
 	s := StyleScrollbarDefault
 
 	expectedLines := []string{

--- a/prompt/utils_test.go
+++ b/prompt/utils_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCalculateViewportRange(t *testing.T) {
+func Test_calculateViewportRange(t *testing.T) {
 	start, stop := calculateViewportRange(5, -1, 5)
 	assert.Equal(t, 0, start)
 	assert.Equal(t, 4, stop)
@@ -54,7 +54,7 @@ func TestCalculateViewportRange(t *testing.T) {
 	assert.Equal(t, 7, stop)
 }
 
-func TestClampValue(t *testing.T) {
+func Test_clampValue(t *testing.T) {
 	assert.Equal(t, 5, clampValue(3, 5, 10))
 	assert.Equal(t, 5, clampValue(5, 5, 10))
 	assert.Equal(t, 7, clampValue(7, 5, 10))
@@ -66,7 +66,7 @@ func TestClampValue(t *testing.T) {
 	assert.Equal(t, 5, clampValue(6, 0, 5))
 }
 
-func TestInsertCursor(t *testing.T) {
+func Test_insertCursor(t *testing.T) {
 	input := "\x1b[38;5;81mselect\x1b[0m\x1b[38;5;231m"
 
 	expectedOutput := "\x1b[38;5;81m\x1b[0m\x1b[38;5;232;48;5;6ms\x1b[0m\x1b[38;5;81melect\x1b[0m\x1b[38;5;231m"
@@ -78,7 +78,7 @@ func TestInsertCursor(t *testing.T) {
 	assert.Equal(t, expectedOutput, output)
 }
 
-func TestOverwriteContent(t *testing.T) {
+func Test_overwriteContent(t *testing.T) {
 	colorContent := Color{
 		Foreground: termenv.ANSI256Color(0),
 		Background: termenv.ANSI256Color(12),
@@ -165,7 +165,7 @@ func TestOverwriteContent(t *testing.T) {
 	})
 }
 
-func BenchmarkStringSubset(b *testing.B) {
+func Benchmark_stringSubset(b *testing.B) {
 	color1 := Color{
 		Foreground: termenv.ANSI256Color(0),
 		Background: termenv.ANSI256Color(12),
@@ -178,7 +178,7 @@ func BenchmarkStringSubset(b *testing.B) {
 	}
 }
 
-func TestStringSubset(t *testing.T) {
+func Test_stringSubset(t *testing.T) {
 	color1 := Color{
 		Foreground: termenv.ANSI256Color(0),
 		Background: termenv.ANSI256Color(12),


### PR DESCRIPTION
Allow clients to force prompt to read from something other than os.Stdin, and write to something other than os.Stdout.

Two new interfaces on Prompter:
- `SetInput(io.Reader)`
- `SetOutput(io.Writer)`
